### PR TITLE
CI import fix

### DIFF
--- a/.github/workflows/run_wat_tests.yml
+++ b/.github/workflows/run_wat_tests.yml
@@ -17,14 +17,8 @@ jobs:
           cp /usr/local/bin/GodotSharp/Api/Release/* .mono/assemblies/Debug
       - name: Compile
         run: msbuild
-      - name: Setup Build
-        run: |
-          mkdir -v -p build/linux build/windows build/mac build/web ~/.local/share/godot/templates
-          mv /root/.local/share/godot/templates/3.3.stable ~/.local/share/godot/templates/3.3.stable
-      - name: Linux Build
-        run: godot -v --export "Linux/X11" ./build/linux/OSLS.x86_64
       - name: Reimport Assets
-        run: godot --editor --quit
+        run: godot --editor --build-solutions --quit
       - name: Run
         run: godot addons/WAT/cli.tscn -run_all
       - name: Upload Test Results

--- a/.github/workflows/run_wat_tests.yml
+++ b/.github/workflows/run_wat_tests.yml
@@ -17,6 +17,12 @@ jobs:
           cp /usr/local/bin/GodotSharp/Api/Release/* .mono/assemblies/Debug
       - name: Compile
         run: msbuild
+      - name: Setup Build
+        run: |
+          mkdir -v -p build/linux build/windows build/mac build/web ~/.local/share/godot/templates
+          mv /root/.local/share/godot/templates/3.3.stable ~/.local/share/godot/templates/3.3.stable
+      - name: Linux Build
+        run: godot -v --export "Linux/X11" ./build/linux/OSLS.x86_64
       - name: Reimport Assets
         run: godot --editor --quit
       - name: Run

--- a/.github/workflows/run_wat_tests.yml
+++ b/.github/workflows/run_wat_tests.yml
@@ -19,6 +19,7 @@ jobs:
         run: msbuild
       - name: Reimport Assets
         run: godot --editor addons/WAT/rebuild_and_close.tscn
+        timeout-minutes: 1
       - name: Run
         run: godot addons/WAT/cli.tscn -run_all
       - name: Upload Test Results

--- a/.github/workflows/run_wat_tests.yml
+++ b/.github/workflows/run_wat_tests.yml
@@ -20,6 +20,7 @@ jobs:
       - name: Reimport Assets
         run: godot --editor addons/WAT/rebuild_and_close.tscn
         timeout-minutes: 1
+        continue-on-error: true
       - name: Run
         run: godot addons/WAT/cli.tscn -run_all
       - name: Upload Test Results

--- a/.github/workflows/run_wat_tests.yml
+++ b/.github/workflows/run_wat_tests.yml
@@ -17,6 +17,8 @@ jobs:
           cp /usr/local/bin/GodotSharp/Api/Release/* .mono/assemblies/Debug
       - name: Compile
         run: msbuild
+      - name: Reimport Assets
+        run: godot --editor --quit
       - name: Run
         run: godot addons/WAT/cli.tscn -run_all
       - name: Upload Test Results

--- a/.github/workflows/run_wat_tests.yml
+++ b/.github/workflows/run_wat_tests.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Compile
         run: msbuild
       - name: Reimport Assets
-        run: godot --editor --build-solutions --quit
+        run: godot --editor addons/WAT/rebuild_and_close.tscn
       - name: Run
         run: godot addons/WAT/cli.tscn -run_all
       - name: Upload Test Results

--- a/addons/WAT/plugin.gd
+++ b/addons/WAT/plugin.gd
@@ -14,6 +14,7 @@ var script_editor: ScriptEditor
 
 func _enter_tree():
 	Settings.initialize()
+	Rebuild.initialize()
 	_initialize_metadata()
 	instance = GUI.instance()
 	docker = Docker.new(self, instance)

--- a/addons/WAT/plugin.gd
+++ b/addons/WAT/plugin.gd
@@ -4,6 +4,7 @@ extends EditorPlugin
 const RUN_CURRENT_SCENE_GODOT_3_2: int = 39
 const RUN_CURRENT_SCENE_GODOT_3_1: int = 33
 const Title: String = "Tests"
+const Rebuild: Script = preload("res://addons/WAT/rebuild_and_close.gd")
 const Settings: Script = preload("res://addons/WAT/settings.gd")
 const GUI: PackedScene = preload("res://addons/WAT/gui.tscn")
 const Docker: Script = preload("res://addons/WAT/ui/scripts/docker.gd")

--- a/addons/WAT/plugin.gd
+++ b/addons/WAT/plugin.gd
@@ -14,7 +14,6 @@ var script_editor: ScriptEditor
 
 func _enter_tree():
 	Settings.initialize()
-	Rebuild.initialize()
 	_initialize_metadata()
 	instance = GUI.instance()
 	docker = Docker.new(self, instance)

--- a/addons/WAT/rebuild_and_close.gd
+++ b/addons/WAT/rebuild_and_close.gd
@@ -1,0 +1,13 @@
+tool
+extends Label
+
+var a = 0.0
+
+func _process(delta):
+	a = a + delta
+	text = String(a)
+	if (a > 10):
+		print("Exiting reimport process...")
+		OS.set_exit_code(1)
+		get_tree().quit()
+	pass

--- a/addons/WAT/rebuild_and_close.gd
+++ b/addons/WAT/rebuild_and_close.gd
@@ -5,12 +5,18 @@ var a = 0.0
 
 func _ready() -> void:
 	print("Starting reimport process...")
+	push_warning("Starting reimport process...")
 
-func _process(delta):
+func _process(delta) -> void:
 	a = a + delta
 	text = String(a)
 	if (a > 10):
 		print("Exiting reimport process...")
+		push_warning("Exiting reimport process...")
 		OS.set_exit_code(1)
 		get_tree().quit()
 	pass
+
+static func initialize() -> void:
+	print("rebuild_and_close is ready")
+	push_warning("rebuild_and_close is ready.")

--- a/addons/WAT/rebuild_and_close.gd
+++ b/addons/WAT/rebuild_and_close.gd
@@ -3,6 +3,9 @@ extends Label
 
 var a = 0.0
 
+func _ready() -> void:
+	print("Starting reimport process...")
+
 func _process(delta):
 	a = a + delta
 	text = String(a)

--- a/addons/WAT/rebuild_and_close.gd
+++ b/addons/WAT/rebuild_and_close.gd
@@ -1,22 +1,16 @@
 tool
 extends Label
 
-var a = 0.0
+var delay = 0.0
 
 func _ready() -> void:
-	print("Starting reimport process...")
 	push_warning("Starting reimport process...")
 
 func _process(delta) -> void:
-	a = a + delta
-	text = String(a)
-	if (a > 10):
-		print("Exiting reimport process...")
+	delay = delay + delta
+	text = String(delay)
+	if (delay > 10):
 		push_warning("Exiting reimport process...")
-		OS.set_exit_code(1)
+		OS.exit_code = 0
 		get_tree().quit()
 	pass
-
-static func initialize() -> void:
-	print("rebuild_and_close is ready")
-	push_warning("rebuild_and_close is ready.")

--- a/addons/WAT/rebuild_and_close.tscn
+++ b/addons/WAT/rebuild_and_close.tscn
@@ -1,0 +1,12 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://addons/WAT/rebuild_and_close.gd" type="Script" id=1]
+
+[node name="Label" type="Label"]
+margin_right = 50.0
+margin_bottom = 25.0
+text = "5.603025"
+script = ExtResource( 1 )
+__meta__ = {
+"_edit_use_anchors_": false
+}


### PR DESCRIPTION
Added one solution to reimport all assets, especially to create immediate files like .mesh, to be able to fully test complete scenes and real setups.
"run: godot --editor --quit" sadly was not enough and there seems to be no direct way at the moment. It is discussed here: https://github.com/godotengine/godot-proposals/issues/1362